### PR TITLE
Fixed calling loadMore too many times

### DIFF
--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -43,25 +43,26 @@ var InfiniteScroll = function (_Component) {
             this.attachScrollListener();
         }
     }, {
-        key: 'componentDidUpdate',
-        value: function componentDidUpdate() {
-            this.attachScrollListener();
+        key: 'componentWillReceiveProps',
+        value: function componentWillReceiveProps(nextProps) {
+            if (nextProps.children.length > this.props.children.length) {
+                this.attachScrollListener();
+            }
         }
     }, {
         key: 'render',
         value: function render() {
-            var _props = this.props;
-            var children = _props.children;
-            var element = _props.element;
-            var hasMore = _props.hasMore;
-            var initialLoad = _props.initialLoad;
-            var loader = _props.loader;
-            var loadMore = _props.loadMore;
-            var pageStart = _props.pageStart;
-            var threshold = _props.threshold;
-            var useWindow = _props.useWindow;
-
-            var props = _objectWithoutProperties(_props, ['children', 'element', 'hasMore', 'initialLoad', 'loader', 'loadMore', 'pageStart', 'threshold', 'useWindow']);
+            var _props = this.props,
+                children = _props.children,
+                element = _props.element,
+                hasMore = _props.hasMore,
+                initialLoad = _props.initialLoad,
+                loader = _props.loader,
+                loadMore = _props.loadMore,
+                pageStart = _props.pageStart,
+                threshold = _props.threshold,
+                useWindow = _props.useWindow,
+                props = _objectWithoutProperties(_props, ['children', 'element', 'hasMore', 'initialLoad', 'loader', 'loadMore', 'pageStart', 'threshold', 'useWindow']);
 
             return _react2.default.createElement(element, props, children, hasMore && (loader || this._defaultLoader));
         }
@@ -76,6 +77,8 @@ var InfiniteScroll = function (_Component) {
     }, {
         key: 'scrollListener',
         value: function scrollListener() {
+            var _this2 = this;
+
             var el = _reactDom2.default.findDOMNode(this);
             var scrollEl = window;
 
@@ -91,7 +94,9 @@ var InfiniteScroll = function (_Component) {
                 this.detachScrollListener();
                 // Call loadMore after detachScrollListener to allow for non-async loadMore functions
                 if (typeof this.props.loadMore == 'function') {
-                    this.props.loadMore(this.pageLoaded += 1);
+                    setTimeout(function () {
+                        _this2.props.loadMore(_this2.pageLoaded += 1);
+                    }, 10);
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "react-infinite-scroller",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Infinite scroll component for React in ES6",
   "main": "dist/InfiniteScroll.js",
   "jsnext:main": "src/InfiniteScroll.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/CassetteRocks/react-infinite-scroller.git"
+    "url": "git@github.com:SAManage/react-infinite-scroller.git"
   },
   "scripts": {
     "build": "mkdir -p dist && babel src/InfiniteScroll.js --presets es2015,react,stage-2 --plugins add-module-exports --out-file dist/InfiniteScroll.js",
@@ -17,10 +17,10 @@
     "scroll",
     "react"
   ],
-  "author": "CassetteRocks",
+  "author": "CassetteRocks / Samanage",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/CassetteRocks/react-infinite-scroller/issues"
+    "url": "https://github.com/SAManage/react-infinite-scroller/issues"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -32,8 +32,10 @@ export default class InfiniteScroll extends Component {
         this.attachScrollListener();
     }
 
-    componentDidUpdate() {
-        this.attachScrollListener();
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.children.length > this.props.children.length) {
+          this.attachScrollListener();
+        }
     }
 
     render() {
@@ -75,8 +77,10 @@ export default class InfiniteScroll extends Component {
         if(offset < Number(this.props.threshold)) {
             this.detachScrollListener();
             // Call loadMore after detachScrollListener to allow for non-async loadMore functions
-            if(typeof this.props.loadMore == 'function') {
+            if (typeof this.props.loadMore == 'function') {
+              setTimeout(() => {
                 this.props.loadMore(this.pageLoaded += 1);
+              }, 10)
             }
         }
     }
@@ -112,7 +116,7 @@ export default class InfiniteScroll extends Component {
     componentWillUnmount() {
         this.detachScrollListener();
     }
-    
+
     // Set a defaut loader for all your `InfiniteScroll` components
     setDefaultLoader(loader) {
         this._defaultLoader = loader;


### PR DESCRIPTION
1. Changed `componentDidUpdate` to `componentWillReceiveProps` and checking that the list of items has grown before putting the scroll listener back.
2. Added a Timeout after removing the listener and before calling `loadMore`
